### PR TITLE
Support of Liquibase contexts in ace-test config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ datasources:
   - dbName: devDb2
     url: jdbc:h2:mem:devdb2
     liquibaseConfig: /liquibase/_liquibase.xml
+    liquibaseContexts: prod
 folders:
   - in
   - out

--- a/src/main/java/com/github/vendigo/acetest/config/DatasourceConfig.java
+++ b/src/main/java/com/github/vendigo/acetest/config/DatasourceConfig.java
@@ -7,5 +7,6 @@ public class DatasourceConfig {
     private String dbName;
     private String url;
     private String liquibaseConfig;
+    private String liquibaseContexts;
     private String schemaFile;
 }

--- a/src/main/java/com/github/vendigo/acetest/db/DatasourceContext.java
+++ b/src/main/java/com/github/vendigo/acetest/db/DatasourceContext.java
@@ -14,6 +14,7 @@ import org.mybatis.spring.SqlSessionFactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
@@ -54,6 +55,10 @@ public class DatasourceContext {
         SpringLiquibase springLiquibase = new SpringLiquibase();
         springLiquibase.setDataSource(datasource);
         springLiquibase.setChangeLog(dsConfig.getLiquibaseConfig());
+        String liquibaseContexts = dsConfig.getLiquibaseContexts();
+        if (!StringUtils.isEmpty(liquibaseContexts)) {
+            springLiquibase.setContexts(liquibaseContexts);
+        }
         springLiquibase.setResourceLoader(new DefaultResourceLoader());
         springLiquibase.setDefaultSchema(H2_DEFAULT_SCHEMA);
         springLiquibase.afterPropertiesSet();

--- a/src/test/java/context/ContextTest.java
+++ b/src/test/java/context/ContextTest.java
@@ -1,0 +1,80 @@
+package context;
+
+import com.github.vendigo.acetest.SpringConfig;
+import com.github.vendigo.acetest.config.Config;
+import com.github.vendigo.acetest.config.DatasourceConfig;
+import com.github.vendigo.acetest.db.DatasourceContext;
+import com.google.common.collect.Iterables;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = SpringConfig.class)
+public class ContextTest {
+    private static final String STATEMENT = "SELECT count(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ?";
+    public static final String COMMON_TABLE = "CommonTable";
+    public static final String TEST_ONLY = "TestOnly";
+    public static final String PROD_ONLY = "ProdOnly";
+
+    @Autowired
+    private Config config;
+    private Map<String, List<DatasourceConfig>> configMap;
+
+    @Before
+    public void groupConfigs() {
+        configMap = config.getDatasources().stream()
+                .filter(dsConfig -> dsConfig.getDbName().startsWith("context"))
+                .collect(Collectors.groupingBy(DatasourceConfig::getDbName));
+    }
+
+    @Test
+    public void dbWithNoContextsAllTablesShouldBeCreated() {
+        DatasourceConfig allDbContext = Iterables.getOnlyElement(configMap.get("contextDb"));
+        testSchema(allDbContext, Arrays.asList(COMMON_TABLE, TEST_ONLY, PROD_ONLY), Collections.emptyList());
+    }
+
+    @Test
+    public void dbWithProdContextNoTestContextTablesShouldBeCreated() {
+        DatasourceConfig prodDbContext = Iterables.getOnlyElement(configMap.get("contextProdDb"));
+        testSchema(prodDbContext, Arrays.asList(COMMON_TABLE, PROD_ONLY), Collections.singletonList(TEST_ONLY));
+    }
+
+    @Test
+    public void dbWithTestContextNoProdTablesShouldBeCreated() {
+        DatasourceConfig testDbContext = Iterables.getOnlyElement(configMap.get("contextTestDb"));
+        testSchema(testDbContext, Arrays.asList(COMMON_TABLE, TEST_ONLY), Collections.singletonList(PROD_ONLY));
+    }
+
+    private void testSchema(DatasourceConfig dsConfig, List<String> presentTables, List<String> absentTables) {
+        JdbcOperations jdbc = createTemplate(dsConfig);
+        presentTables.forEach(table -> assertTable(jdbc, table, 1));
+        absentTables.forEach(table -> assertTable(jdbc, table, 0));
+    }
+
+    private void assertTable(JdbcOperations jdbc, String tableName, long expectedCount) {
+        long count = jdbc.queryForObject(STATEMENT, Long.class, tableName);
+        assertEquals(expectedCount, count);
+    }
+
+    private JdbcOperations createTemplate(DatasourceConfig dsConfig) {
+        BasicDataSource dataSource = new BasicDataSource();
+        dataSource.setDriverClassName(DatasourceContext.H2_DRIVER_CLASSNAME);
+        dataSource.setUrl(dsConfig.getUrl());
+        return new JdbcTemplate(dataSource);
+    }
+}

--- a/src/test/resources/ace-test-settings.yaml
+++ b/src/test/resources/ace-test-settings.yaml
@@ -6,6 +6,17 @@ datasources:
     url: jdbc:h2:mem:devdb
     schemaFile: schema.sql
     liquibaseConfig: /liquibase/_liquibase.xml
+  - dbName: contextDb
+    url: jdbc:h2:mem:contextDb;DATABASE_TO_UPPER=false;
+    liquibaseConfig: /liquibase/context/_liquibase.xml
+  - dbName: contextProdDb
+    url: jdbc:h2:mem:contextProdDb;DATABASE_TO_UPPER=false;
+    liquibaseConfig: /liquibase/context/_liquibase.xml
+    liquibaseContexts: "prod"
+  - dbName: contextTestDb
+    url: jdbc:h2:mem:contextTestDb;DATABASE_TO_UPPER=false;
+    liquibaseConfig: /liquibase/context/_liquibase.xml
+    liquibaseContexts: "test"
 folders:
   - in
   - out

--- a/src/test/resources/ace-test-settings.yaml
+++ b/src/test/resources/ace-test-settings.yaml
@@ -2,8 +2,8 @@ launchers:
   - appName: TestApp
     className: test.app.Launcher
 datasources:
-  - dbName: devDb
-    url: jdbc:h2:mem:devdb
+  - dbName: AceTest
+    url: jdbc:h2:mem:AceTest
     schemaFile: schema.sql
     liquibaseConfig: /liquibase/_liquibase.xml
   - dbName: contextDb

--- a/src/test/resources/cucumber/Sample.feature
+++ b/src/test/resources/cucumber/Sample.feature
@@ -3,26 +3,26 @@ Feature: Sample
   Background:
     Given Properties:
       | db.driverClassName=org.h2.Driver |
-      | db.url=jdbc:h2:mem:devdb         |
+      | db.url=jdbc:h2:mem:AceTest         |
       | input.dir=${in.dir}              |
       | output.dir=${out.dir}            |
 
   Scenario: Population of product.csv and country filtering
     Given Properties:
       | area.limit=400000 |
-    And Table Country is empty
+    And AceTest table Country is empty
     And File countries.csv in folder in with lines:
       | name, capital, currency, region, area, independenceDay |
       | Ukraine, Kyiv, UAH, Europe, 603700, 1991-08-24         |
       | Germany, Berlin, EUR, Europe, 357021,                  |
       | France, Paris, EUR, Europe, 643801,                    |
-    And Table Product with records:
+    And AceTest table Product with records:
       | id | name                       | description                              | price  | insertDate | lastUpdateTime   |
       | 1  | Mi Band 1s                 | Fitness band from Xiaomi, 1nd generation | 949.99 | 2016-05-20 | 2016-11-05 20:00 |
       | 2  | Mi Band 2                  | Fitness band from Xiaomi, 2nd generation | 429.00 | 2015-02-22 | 2016-11-06 16:30 |
       | 3  | Xiaomi Huami Amazfit Watch | {empty}                                  | 4499   | 2016-11-02 | 2016-11-02 10:35 |
     When Application TestApp runs
-    Then Table Country will have records:
+    Then AceTest table Country will have records:
       | name    | capital | currency | region | area   | independenceDay |
       | Ukraine | Kyiv    | UAH      | Europe | 603700 | 1991-08-24      |
       | France  | Paris   | EUR      | Europe | 643801 | {null}          |
@@ -36,14 +36,14 @@ Feature: Sample
   Scenario: Ignoring area limit
     Given Properties:
       | area.limit=400000 |
-    And Table Country is empty
+    And AceTest table Country is empty
     And File countries.csv in folder in with lines:
       | name, capital, currency, region, area, independenceDay |
       | Ukraine, Kyiv, UAH, Europe, 603700, 1991-08-24         |
       | Germany, Berlin, EUR, Europe, 357021,                  |
       | France, Paris, EUR, Europe, 643801,                    |
     When Application TestApp runs with params: '-disableAreaLimit'
-    Then Table Country will have records:
+    Then AceTest table Country will have records:
       | name    | capital | currency | region | area   | independenceDay |
       | Ukraine | Kyiv    | UAH      | Europe | 603700 | 1991-08-24      |
       | Germany | Berlin  | EUR      | Europe | 357021 | {null}          |
@@ -60,14 +60,14 @@ Feature: Sample
       | Ukraine, Kyiv, UAH, Europe, 603700, 1991-08-24         |
       | Germany, Berlin, EUR, Europe, 357021,                  |
       | France, Paris, EUR, Europe, 643801,                    |
-    And Table Product with records:
+    And AceTest table Product with records:
       | id | name                       | description                              | price  | insertDate | lastUpdateTime   |
       | 1  | Mi Band 1s                 | Fitness band from Xiaomi, 1nd generation | 949.99 | 2016-05-20 | 2016-11-05 20:00 |
       | 2  | Mi Band 2                  | Fitness band from Xiaomi, 2nd generation | 429.00 | 2015-02-22 | 2016-11-06 16:30 |
       | 3  | Xiaomi Huami Amazfit Watch | {empty}                                  | 4499   | 2016-11-02 | 2016-11-02 10:35 |
       | 4  | "2048"                     | Interactive game 2048                    | 200.5  | 2016-11-25 | 2016-11-26 08:01 |
     When Application TestApp runs
-    Then Table Product will have records:
+    Then AceTest table Product will have records:
       | id | name                       | description                              | price  | insertDate | lastUpdateTime   |
       | 1  | Mi Band 1s                 | Fitness band from Xiaomi, 1nd generation | 949.99 | 2016-05-20 | 2016-11-05 20:00 |
       | 2  | Mi Band 2                  | Fitness band from Xiaomi, 2nd generation | 429.00 | 2015-02-22 | 2016-11-06 16:30 |

--- a/src/test/resources/liquibase/context/_liquibase.xml
+++ b/src/test/resources/liquibase/context/_liquibase.xml
@@ -1,0 +1,30 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <changeSet id="common" author="leostep">
+        <createTable tableName="CommonTable">
+            <column name="id" type="bigint">
+                <constraints primaryKey="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="nonTest" author="leostep" context="!test">
+        <createTable tableName="ProdOnly">
+            <column name="id" type="bigint">
+                <constraints primaryKey="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="testOnly" author="leostep" context="test">
+        <createTable tableName="TestOnly">
+            <column name="id" type="bigint">
+                <constraints primaryKey="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Hi, Dima.
Added a small feature - support of liquibase contexts in
ace-test-config. Contexts may be useful specifically for testing
purposes when there is a need to filter out or add some specific
changeSets when applying liquibase in tests.
So this feature may be useful for such a nice testing tool.

Please take a look at this pull request, maybe you'll find it useful :)

[Contexts](http://www.liquibase.org/documentation/contexts.html)